### PR TITLE
Initialise MkDocs documentation site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,203 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+#poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+#pdm.lock
+#pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Abstra
+# Abstra is an AI-powered process automation framework.
+# Ignore directories containing user credentials, local state, and settings.
+# Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml

--- a/README.md
+++ b/README.md
@@ -1,33 +1,3 @@
 # Aviation
 
 Simple (super low order) model of global aviation. Enjoy!
-
-## Basic Model
-The "required global fleet" can be estimated using a very simple model that assumes the number of passengers flying globally annually is known, along with an estimation of the number of seats flown globally per day.
-
-Many assumptions are made to make the model simple. These include assuming the same aircraft services the same route all year round. Given that the two sources used in this model are given in different time bases, they are converted to per day values to maintain consistency. The first equation gives an estimate of the global passengers flying per day:
-
-$\text{Passengers Per Day} = \frac{\text{Passengers Per Year}}{\text{Days Per Year}}$
-
-The total required global fleet can then be calculated as a function of this intermediate value and the other inputs:
-
-$\text{Required Global Fleet} = \frac{\text{Passengers Per Day}}{\text{Seats Per Aircraft}\ \times\ \text{Flights Per Aircraft Per Day}}$
-
-With the equations established, we can assign values to these variables using real world data from 2023 and a bit of guess work:
-
-| Variable | Value | Source |
-| -------- | ----- | ------ |
-| Passengers Per Year | $8.7 \times 10^9$ | ACI [^1] |
-| Seats Per Aircraft | $181$ | CAA [^2] |
-| Flights Per Aircraft Per Day | $4$ | Guess |
-
-Putting these numbers into the equations:
-
-$\text{Passengers Per Day} = \frac{8.7 \times 10^9}{365.25} = 2.4 \times 10^7$
-
-$\text{Required Global Fleet} = \frac{2.4 \times 10^7}{181 \times\ 4} = 33149$
-
-
-[^1]: Airports International Council  World Airport Traffic Forecasts 2023-2052. Figure from 2023. `https://store.aci.aero/wp-content/uploads/2024/02/WATF-Executive-Summary.pdf`
-
-[^2]: Civil Aviation Authority Quarterly Statistics. Figure from 2023. `https://www.caa.co.uk/data-and-analysis/uk-aviation-market/airports/uk-airport-data/latest-quarterly-statistics/`

--- a/docs/aviation.md
+++ b/docs/aviation.md
@@ -1,0 +1,31 @@
+# Aviation
+
+## Documentation
+The "required global fleet" can be estimated using a very simple model that assumes the number of passengers flying globally annually is known, along with an estimation of the number of seats flown globally per day.
+
+Many assumptions are made to make the model simple. These include assuming the same aircraft services the same route all year round. Given that the two sources used in this model are given in different time bases, they are converted to per day values to maintain consistency. The first equation gives an estimate of the global passengers flying per day:
+
+$\text{Passengers Per Day} = \frac{\text{Passengers Per Year}}{\text{Days Per Year}}$
+
+The total required global fleet can then be calculated as a function of this intermediate value and the other inputs:
+
+$\text{Required Global Fleet} = \frac{\text{Passengers Per Day}}{\text{Seats Per Aircraft}\ \times\ \text{Flights Per Aircraft Per Day}}$
+
+With the equations established, we can assign values to these variables using real world data from 2023 and a bit of guess work:
+
+| Variable | Value | Source |
+| -------- | ----- | ------ |
+| Passengers Per Year | $8.7 \times 10^9$ | ACI [^1] |
+| Seats Per Aircraft | $181$ | CAA [^2] |
+| Flights Per Aircraft Per Day | $4$ | Guess |
+
+Putting these numbers into the equations:
+
+$\text{Passengers Per Day} = \frac{8.7 \times 10^9}{365.25} = 2.4 \times 10^7$
+
+$\text{Required Global Fleet} = \frac{2.4 \times 10^7}{181 \times\ 4} = 33149$
+
+
+[^1]: Airports International Council  World Airport Traffic Forecasts 2023-2052. Value from 2023. `https://store.aci.aero/wp-content/uploads/2024/02/WATF-Executive-Summary.pdf`
+
+[^2]: Civil Aviation Authority Quarterly Statistics. Value from 2023. `https://www.caa.co.uk/data-and-analysis/uk-aviation-market/airports/uk-airport-data/latest-quarterly-statistics/`

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# Welcome to MkDocs
+
+For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+
+## Commands
+
+* `mkdocs new [dir-name]` - Create a new project.
+* `mkdocs serve` - Start the live-reloading docs server.
+* `mkdocs build` - Build the documentation site.
+* `mkdocs -h` - Print help message and exit.
+
+## Project layout
+
+    mkdocs.yml    # The configuration file.
+    docs/
+        index.md  # The documentation homepage.
+        ...       # Other markdown pages, images and other files.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,5 @@
-# Welcome to MkDocs
+# Welcome to "Aviation"
 
-For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+A simple model of global aviation.
 
-## Commands
-
-* `mkdocs new [dir-name]` - Create a new project.
-* `mkdocs serve` - Start the live-reloading docs server.
-* `mkdocs build` - Build the documentation site.
-* `mkdocs -h` - Print help message and exit.
-
-## Project layout
-
-    mkdocs.yml    # The configuration file.
-    docs/
-        index.md  # The documentation homepage.
-        ...       # Other markdown pages, images and other files.
+Click [here](./aviation.md) to view the model documentation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,1 @@
+site_name: My Docs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,1 +1,5 @@
 site_name: My Docs
+
+nav:
+  - Home: 'index.md'
+  - Aviation Model: 'aviation.md'


### PR DESCRIPTION
This PR initialises a documentation site using MkDocs. It migrates the documentation previously written in `README.md` into the new MkDocs `docs/` directory and splits the documentation between two files, `docs/index.md` and `docs/aviation.md`. It also sets up the navigation for the site in `mkdocs.yml`.