### PR TITLE
Configure Ruff for linting and formatting Python code

### DIFF
--- a/analysis/passengers_per_day.py
+++ b/analysis/passengers_per_day.py
@@ -5,6 +5,8 @@ days_per_yer = 365.25
 seats_per_aircraft = 181.0
 flights_per_aircraft_per_day = 4.0
 
-passengers_per_day = aviation.calculate_passengers_per_day(passengers_per_year=passengers_per_year, days_per_yer=days_per_yer)
+passengers_per_day = aviation.calculate_passengers_per_day(
+    passengers_per_year=passengers_per_year, days_per_yer=days_per_yer
+)
 
 print(f"Passengers Per Day = {passengers_per_day:.0f}")

--- a/analysis/required._global_fleet.py
+++ b/analysis/required._global_fleet.py
@@ -5,10 +5,13 @@ days_per_yer = 365.25
 seats_per_aircraft = 181.0
 flights_per_aircraft_per_day = 4.0
 
-passengers_per_day = aviation.calculate_passengers_per_day(passengers_per_year=passengers_per_year, days_per_yer=days_per_yer)
+passengers_per_day = aviation.calculate_passengers_per_day(
+    passengers_per_year=passengers_per_year, days_per_yer=days_per_yer
+)
 required_global_fleet = aviation.calculate_required_global_fleet(
-                                                            passengers_per_day=passengers_per_day, 
-                                                            seats_per_aircraft=seats_per_aircraft, 
-                                                            flights_per_aircraft_per_day=flights_per_aircraft_per_day)
+    passengers_per_day=passengers_per_day,
+    seats_per_aircraft=seats_per_aircraft,
+    flights_per_aircraft_per_day=flights_per_aircraft_per_day,
+)
 
 print(f"Global Fleet Requirement = {required_global_fleet:.0f} Aircraft")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,8 +3,8 @@ theme:
   name: material
 
 nav:
-  - Home: 'index.md'
-  - Aviation Model: 'aviation.md'
+  - Home: "index.md"
+  - Aviation Model: "aviation.md"
 
 markdown_extensions:
   - footnotes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ docs = [
 ]
 
 [tool.uv]
-default-groups = ["docs"]
+default-groups = ["dev", "docs"]
 
 [build-system]
 requires = ["uv_build>=0.7.21,<0.8.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ requires-python = ">=3.12"
 dependencies = []
 
 [dependency-groups]
+dev = [
+    "ruff>=0.12.3",
+]
 docs = [
     "mkdocs-bibtex>=4.4.0",
     "mkdocs-material>=9.6.15",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,24 @@ docs = [
     "mkdocs-material>=9.6.15",
 ]
 
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+    "B",
+    "E",
+    "F",
+    "I",
+    "N",
+    "SIM",
+    "T",
+    "UP"
+]
+
+[tool.ruff.lint.per-file-ignores]
+"analysis/*" = ["T201"]
+
 [tool.uv]
 default-groups = ["dev", "docs"]
 

--- a/src/aviation/__init__.py
+++ b/src/aviation/__init__.py
@@ -1,6 +1,6 @@
 __all__ = ("calculate_required_global_fleet", "calculate_passengers_per_day")
 
 from aviation.aviation import (
-    calculate_required_global_fleet,
     calculate_passengers_per_day,
+    calculate_required_global_fleet,
 )

--- a/src/aviation/__init__.py
+++ b/src/aviation/__init__.py
@@ -1,3 +1,6 @@
 __all__ = ("calculate_required_global_fleet", "calculate_passengers_per_day")
 
-from aviation.aviation import calculate_required_global_fleet, calculate_passengers_per_day
+from aviation.aviation import (
+    calculate_required_global_fleet,
+    calculate_passengers_per_day,
+)

--- a/src/aviation/aviation.py
+++ b/src/aviation/aviation.py
@@ -1,5 +1,8 @@
 def calculate_passengers_per_day(passengers_per_year, days_per_yer):
     return passengers_per_year / days_per_yer
 
-def calculate_required_global_fleet(passengers_per_day, seats_per_aircraft, flights_per_aircraft_per_day):
-    return passengers_per_day / (seats_per_aircraft * flights_per_aircraft_per_day)    
+
+def calculate_required_global_fleet(
+    passengers_per_day, seats_per_aircraft, flights_per_aircraft_per_day
+):
+    return passengers_per_day / (seats_per_aircraft * flights_per_aircraft_per_day)

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,9 @@ version = "0.1.0"
 source = { editable = "." }
 
 [package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
 docs = [
     { name = "mkdocs-bibtex" },
     { name = "mkdocs-material" },
@@ -16,6 +19,7 @@ docs = [
 [package.metadata]
 
 [package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.12.3" }]
 docs = [
     { name = "mkdocs-bibtex", specifier = ">=4.4.0" },
     { name = "mkdocs-material", specifier = ">=9.6.15" },
@@ -451,6 +455,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/7e/2345ac3299bd62bd7163216702bbc88976c099cfceba5b889f2a457727a1/responses-0.25.7.tar.gz", hash = "sha256:8ebae11405d7a5df79ab6fd54277f6f2bc29b2d002d0dd2d5c632594d1ddcedb", size = 79203, upload-time = "2025-03-11T15:36:16.624Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/fc/1d20b64fa90e81e4fa0a34c9b0240a6cfb1326b7e06d18a5432a9917c316/responses-0.25.7-py3-none-any.whl", hash = "sha256:92ca17416c90fe6b35921f52179bff29332076bb32694c0df02dcac2c6bc043c", size = 34732, upload-time = "2025-03-11T15:36:14.589Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.12.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/2a/43955b530c49684d3c38fcda18c43caf91e99204c2a065552528e0552d4f/ruff-0.12.3.tar.gz", hash = "sha256:f1b5a4b6668fd7b7ea3697d8d98857390b40c1320a63a178eee6be0899ea2d77", size = 4459341, upload-time = "2025-07-11T13:21:16.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/fd/b44c5115539de0d598d75232a1cc7201430b6891808df111b8b0506aae43/ruff-0.12.3-py3-none-linux_armv6l.whl", hash = "sha256:47552138f7206454eaf0c4fe827e546e9ddac62c2a3d2585ca54d29a890137a2", size = 10430499, upload-time = "2025-07-11T13:20:26.321Z" },
+    { url = "https://files.pythonhosted.org/packages/43/c5/9eba4f337970d7f639a37077be067e4ec80a2ad359e4cc6c5b56805cbc66/ruff-0.12.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0a9153b000c6fe169bb307f5bd1b691221c4286c133407b8827c406a55282041", size = 11213413, upload-time = "2025-07-11T13:20:30.017Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/2c/fac3016236cf1fe0bdc8e5de4f24c76ce53c6dd9b5f350d902549b7719b2/ruff-0.12.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fa6b24600cf3b750e48ddb6057e901dd5b9aa426e316addb2a1af185a7509882", size = 10586941, upload-time = "2025-07-11T13:20:33.046Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/0f/41fec224e9dfa49a139f0b402ad6f5d53696ba1800e0f77b279d55210ca9/ruff-0.12.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2506961bf6ead54887ba3562604d69cb430f59b42133d36976421bc8bd45901", size = 10783001, upload-time = "2025-07-11T13:20:35.534Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ca/dd64a9ce56d9ed6cad109606ac014860b1c217c883e93bf61536400ba107/ruff-0.12.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c4faaff1f90cea9d3033cbbcdf1acf5d7fb11d8180758feb31337391691f3df0", size = 10269641, upload-time = "2025-07-11T13:20:38.459Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5c/2be545034c6bd5ce5bb740ced3e7014d7916f4c445974be11d2a406d5088/ruff-0.12.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40dced4a79d7c264389de1c59467d5d5cefd79e7e06d1dfa2c75497b5269a5a6", size = 11875059, upload-time = "2025-07-11T13:20:41.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d4/a74ef1e801ceb5855e9527dae105eaff136afcb9cc4d2056d44feb0e4792/ruff-0.12.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:0262d50ba2767ed0fe212aa7e62112a1dcbfd46b858c5bf7bbd11f326998bafc", size = 12658890, upload-time = "2025-07-11T13:20:44.442Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c8/1057916416de02e6d7c9bcd550868a49b72df94e3cca0aeb77457dcd9644/ruff-0.12.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12371aec33e1a3758597c5c631bae9a5286f3c963bdfb4d17acdd2d395406687", size = 12232008, upload-time = "2025-07-11T13:20:47.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/59/4f7c130cc25220392051fadfe15f63ed70001487eca21d1796db46cbcc04/ruff-0.12.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:560f13b6baa49785665276c963edc363f8ad4b4fc910a883e2625bdb14a83a9e", size = 11499096, upload-time = "2025-07-11T13:20:50.348Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/01/a0ad24a5d2ed6be03a312e30d32d4e3904bfdbc1cdbe63c47be9d0e82c79/ruff-0.12.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:023040a3499f6f974ae9091bcdd0385dd9e9eb4942f231c23c57708147b06311", size = 11688307, upload-time = "2025-07-11T13:20:52.945Z" },
+    { url = "https://files.pythonhosted.org/packages/93/72/08f9e826085b1f57c9a0226e48acb27643ff19b61516a34c6cab9d6ff3fa/ruff-0.12.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:883d844967bffff5ab28bba1a4d246c1a1b2933f48cb9840f3fdc5111c603b07", size = 10661020, upload-time = "2025-07-11T13:20:55.799Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a0/68da1250d12893466c78e54b4a0ff381370a33d848804bb51279367fc688/ruff-0.12.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:2120d3aa855ff385e0e562fdee14d564c9675edbe41625c87eeab744a7830d12", size = 10246300, upload-time = "2025-07-11T13:20:58.222Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/22/5f0093d556403e04b6fd0984fc0fb32fbb6f6ce116828fd54306a946f444/ruff-0.12.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6b16647cbb470eaf4750d27dddc6ebf7758b918887b56d39e9c22cce2049082b", size = 11263119, upload-time = "2025-07-11T13:21:01.503Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c9/f4c0b69bdaffb9968ba40dd5fa7df354ae0c73d01f988601d8fac0c639b1/ruff-0.12.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e1417051edb436230023575b149e8ff843a324557fe0a265863b7602df86722f", size = 11746990, upload-time = "2025-07-11T13:21:04.524Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/84/7cc7bd73924ee6be4724be0db5414a4a2ed82d06b30827342315a1be9e9c/ruff-0.12.3-py3-none-win32.whl", hash = "sha256:dfd45e6e926deb6409d0616078a666ebce93e55e07f0fb0228d4b2608b2c248d", size = 10589263, upload-time = "2025-07-11T13:21:07.148Z" },
+    { url = "https://files.pythonhosted.org/packages/07/87/c070f5f027bd81f3efee7d14cb4d84067ecf67a3a8efb43aadfc72aa79a6/ruff-0.12.3-py3-none-win_amd64.whl", hash = "sha256:a946cf1e7ba3209bdef039eb97647f1c77f6f540e5845ec9c114d3af8df873e7", size = 11695072, upload-time = "2025-07-11T13:21:11.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/30/f3eaf6563c637b6e66238ed6535f6775480db973c836336e4122161986fc/ruff-0.12.3-py3-none-win_arm64.whl", hash = "sha256:5f9c7c9c8f84c2d7f27e93674d27136fbf489720251544c4da7fb3d742e011b1", size = 10805855, upload-time = "2025-07-11T13:21:13.547Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds [Ruff](https://astral.sh/ruff/) to a new `dev` dependency group to allow for linting and formatting of Python code. This new dependency group is added to the default in the uv configuration. The Ruff formatter is used to auto format Python files and the Ruff linter is run with all detected violations fixed.