### PR TITLE
Add `SystemsModel` class

### DIFF
--- a/analysis/passengers_per_day.py
+++ b/analysis/passengers_per_day.py
@@ -5,7 +5,7 @@ import aviation
 passengers_per_year = 9_000_000_000.0
 days_per_year = 365.25
 
-passengers_per_day = aviation.calculate_passengers_per_day(
+passengers_per_day = aviation.passengers_per_day(
     passengers_per_year=passengers_per_year, days_per_year=days_per_year
 )
 

--- a/analysis/required_global_fleet.py
+++ b/analysis/required_global_fleet.py
@@ -1,19 +1,21 @@
 """Analysis to determine the global fleet requirement based on average passenger and flight data."""
 
 import aviation
+from aviation import _engine as engine
 
 passengers_per_year = 9_000_000_000.0
 days_per_year = 365.25
 seats_per_aircraft = 181.0
 flights_per_aircraft_per_day = 4.0
 
-passengers_per_day = aviation.calculate_passengers_per_day(
-    passengers_per_year=passengers_per_year, days_per_year=days_per_year
-)
-required_global_fleet = aviation.calculate_required_global_fleet(
-    passengers_per_day=passengers_per_day,
-    seats_per_aircraft=seats_per_aircraft,
-    flights_per_aircraft_per_day=flights_per_aircraft_per_day,
-)
+inputs = {
+    "passengers_per_year": passengers_per_year,
+    "days_per_year": days_per_year,
+    "seats_per_aircraft": seats_per_aircraft,
+    "flights_per_aircraft_day": flights_per_aircraft_per_day,
+}
+output = "required_global_fleet"
 
+systems_model = engine.SystemsModel(aviation.transforms)
+required_global_fleet = systems_model.evaluate(inputs, output)
 print(f"Global Fleet Requirement = {required_global_fleet:.0f} Aircraft")

--- a/src/aviation/__init__.py
+++ b/src/aviation/__init__.py
@@ -5,9 +5,11 @@ Modules:
 
 """
 
-__all__ = ("calculate_passengers_per_day", "calculate_required_global_fleet")
+__all__ = ("passengers_per_day", "required_global_fleet", "transforms")
 
 from aviation.fleet import (
-    calculate_passengers_per_day,
-    calculate_required_global_fleet,
+    passengers_per_day,
+    required_global_fleet,
 )
+
+transforms = (passengers_per_day, required_global_fleet)

--- a/src/aviation/_engine.py
+++ b/src/aviation/_engine.py
@@ -1,0 +1,38 @@
+import collections.abc
+import typing
+
+from aviation._model import Transform
+
+
+class SystemsModel:
+    """A system of models formed by a sequence of transforms."""
+
+    def __init__(self, transforms: collections.abc.Sequence[Transform[typing.Any, ...]]) -> None:
+        """Initialise the system model from a sequence of transforms."""
+        self.transforms = set(transforms)
+
+    def evaluate(self, inputs: dict[str, typing.Any], output: str) -> typing.Any:  # noqa: ANN401
+        """Calculate the value returned by a transform."""
+        # If the requested `output` has already been supplied as an input then this can be returned
+        # directly without need for computation.
+        if output in inputs:
+            return inputs[output]
+
+        # The request `output` is not in `inputs` so it must be the name of a transform in
+        # `self.transforms`. If it's not found in `self.transforms` then there must be an error.
+        for transform in self.transforms:
+            if transform.name == output:
+                break
+        else:
+            message = f"No transform with name {output}"
+            raise ValueError(message)
+
+        # To evaluate the `transform`, arguments for all of its parameters are required. If a
+        # parameter is not found in the inputs, evaluate that parameter from its own transform.
+        for parameter in transform.parameters:
+            if parameter not in inputs:
+                inputs[parameter] = self.evaluate(inputs, parameter)
+
+        # Evaluate and return the `transform` associated with the passed `output`.
+        arguments = {parameter: inputs[parameter] for parameter in transform.parameters}
+        return transform(**arguments)

--- a/src/aviation/fleet.py
+++ b/src/aviation/fleet.py
@@ -1,12 +1,12 @@
 """Modelling of the global fleet using average passenger flight data."""
 
-__all__ = ("calculate_passengers_per_day", "calculate_required_global_fleet")
+__all__ = ("passengers_per_day", "required_global_fleet")
 
 from aviation._model import transform
 
 
 @transform
-def calculate_passengers_per_day(passengers_per_year: float, days_per_year: float) -> float:
+def passengers_per_day(passengers_per_year: float, days_per_year: float) -> float:
     """Calculates the number of passengers per day globally.
 
     Args:
@@ -18,7 +18,7 @@ def calculate_passengers_per_day(passengers_per_year: float, days_per_year: floa
 
 
 @transform
-def calculate_required_global_fleet(
+def required_global_fleet(
     passengers_per_day: float, seats_per_aircraft: float, flights_per_aircraft_per_day: float
 ) -> float:
     """Calculate the size of the required global fleet.

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,43 @@
+import typing
+
+import pytest
+
+import aviation
+from aviation import _engine as engine
+
+
+@pytest.fixture
+def systems_model() -> engine.SystemsModel:
+    return engine.SystemsModel(aviation.transforms)
+
+
+@pytest.mark.parametrize(
+    ("inputs", "output", "expected"),
+    (
+        ({"passengers_per_year": 5_000_000_000.0}, "passengers_per_year", 5_000_000_000.0),
+        ({"required_global_fleet": 25_000.0}, "required_global_fleet", 25_000.0),
+        (
+            {"passengers_per_year": 9_000_000_000.0, "days_per_year": 365.25},
+            "passengers_per_day",
+            24_640_657.0,
+        ),
+        (
+            {
+                "days_per_year": 365.25,
+                "passengers_per_year": 9_000_000_000.0,
+                "seats_per_aircraft": 181.0,
+                "flights_per_aircraft_per_day": 4.0,
+            },
+            "required_global_fleet",
+            34_000.0,
+        ),
+    ),
+)
+def test_systems_model_evaluate(
+    systems_model: engine.SystemsModel,
+    inputs: dict[str, typing.Any],
+    output: str,
+    expected: float,
+) -> None:
+    result = systems_model.evaluate(inputs, output)
+    assert result == pytest.approx(expected, rel=0.1)

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -1,6 +1,6 @@
 import pytest
 
-from aviation.fleet import calculate_passengers_per_day, calculate_required_global_fleet
+from aviation.fleet import passengers_per_day, required_global_fleet
 
 
 @pytest.mark.parametrize(
@@ -13,10 +13,7 @@ from aviation.fleet import calculate_passengers_per_day, calculate_required_glob
 def test_passengers_per_day(
     passengers_per_year: float, days_per_year: float, expected_passengers_per_day: float
 ) -> None:
-    assert (
-        calculate_passengers_per_day(passengers_per_year, days_per_year)
-        == expected_passengers_per_day
-    )
+    assert passengers_per_day(passengers_per_year, days_per_year) == expected_passengers_per_day
 
 
 def test_required_global_fleet() -> None:
@@ -27,8 +24,8 @@ def test_required_global_fleet() -> None:
 
     expected_required_global_fleet = 25_000.0
 
-    result = calculate_required_global_fleet(
-        calculate_passengers_per_day(passengers_per_year, days_per_year),
+    result = required_global_fleet(
+        passengers_per_day(passengers_per_year, days_per_year),
         seats_per_aircraft,
         flights_per_aircraft_per_day,
     )


### PR DESCRIPTION
This PR adds the `SystemsModel` class, like the one from camia-engine, which can define a systems model from a sequence of transfroms and evaluate a specific transfrom as an output from a group of given inputs.