### PR TITLE
Use camia-model's units system 

### DIFF
--- a/analysis/passengers_per_day.py
+++ b/analysis/passengers_per_day.py
@@ -1,11 +1,13 @@
 """Analysis to determine the average number of passengers flying daily."""
 
 import camia_engine as engine
+from camia_model.units import day, year
 
 import aviation
+from aviation.units import passenger
 
-passengers_per_year = 9_000_000_000.0
-days_per_year = 365.25
+passengers_per_year = 9_000_000_000.0 * passenger / year
+days_per_year = 365.25 * day / year
 
 inputs = {"days_per_year": days_per_year, "passengers_per_year": passengers_per_year}
 output = "passengers_per_day"
@@ -13,4 +15,4 @@ output = "passengers_per_day"
 systems_model = engine.SystemsModel(aviation.transforms)
 passengers_per_day = systems_model.evaluate(inputs, output)
 
-print(f"Passengers Per Day = {passengers_per_day:.0f}")
+print(f"Passengers Per Day = {passengers_per_day.value}")

--- a/analysis/passengers_per_day.py
+++ b/analysis/passengers_per_day.py
@@ -1,18 +1,17 @@
 """Analysis to determine the average number of passengers flying daily."""
 
 import camia_engine as engine
-from camia_model.units import day, year
+from camia_model.units import year
 
 import aviation
 from aviation.units import passenger
 
 passengers_per_year = 9_000_000_000.0 * passenger / year
-days_per_year = 365.25 * day / year
 
-inputs = {"days_per_year": days_per_year, "passengers_per_year": passengers_per_year}
+inputs = {"passengers_per_year": passengers_per_year}
 output = "passengers_per_day"
 
 systems_model = engine.SystemsModel(aviation.transforms)
 passengers_per_day = systems_model.evaluate(inputs, output)
 
-print(f"Passengers Per Day = {passengers_per_day.value}")
+print(f"Passengers Per Day = {passengers_per_day}")

--- a/analysis/required_global_fleet.py
+++ b/analysis/required_global_fleet.py
@@ -1,13 +1,15 @@
 """Analysis to determine the global fleet requirement based on average passenger and flight data."""
 
 import camia_engine as engine
+from camia_model.units import day, year
 
 import aviation
+from aviation.units import aircraft, journey, passenger
 
-passengers_per_year = 9_000_000_000.0
-days_per_year = 365.25
-seats_per_aircraft = 181.0
-flights_per_aircraft_per_day = 4.0
+passengers_per_year = 9_000_000_000.0 * passenger / year
+days_per_year = 365.25 * day / year
+seats_per_aircraft = 181.0 * passenger / aircraft
+flights_per_aircraft_per_day = 4.0 * journey / (aircraft * day)
 
 inputs = {
     "passengers_per_year": passengers_per_year,
@@ -19,4 +21,4 @@ output = "required_global_fleet"
 
 systems_model = engine.SystemsModel(aviation.transforms)
 required_global_fleet = systems_model.evaluate(inputs, output)
-print(f"Global Fleet Requirement = {required_global_fleet:.0f} Aircraft")
+print(f"Global Fleet Requirement = {required_global_fleet.value:.0f} {required_global_fleet.unit}")

--- a/analysis/required_global_fleet.py
+++ b/analysis/required_global_fleet.py
@@ -7,13 +7,11 @@ import aviation
 from aviation.units import aircraft, journey, passenger
 
 passengers_per_year = 9_000_000_000.0 * passenger / year
-days_per_year = 365.25 * day / year
 seats_per_aircraft = 181.0 * passenger / aircraft
 flights_per_aircraft_per_day = 4.0 * journey / (aircraft * day)
 
 inputs = {
     "passengers_per_year": passengers_per_year,
-    "days_per_year": days_per_year,
     "seats_per_aircraft": seats_per_aircraft,
     "flights_per_aircraft_per_day": flights_per_aircraft_per_day,
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,13 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["mypy>=1.17.0", "pre-commit>=4.2.0", "pytest>=8.4.1", "ruff>=0.12.3"]
+dev = [
+    "mypy>=1.17.0",
+ "pre-commit>=4.2.0",
+ "pytest>=8.4.1",
+ "pytest-camia>=0.3.3",
+ "ruff>=0.12.3",
+]
 docs = [
     "mkdocs-bibtex>=4.4.0",
     "mkdocs-material>=9.6.15",

--- a/src/aviation/fleet.py
+++ b/src/aviation/fleet.py
@@ -13,7 +13,6 @@ from aviation.units import aircraft, journey, passenger
 @model.transform
 def passengers_per_day(
     passengers_per_year: typing.Annotated[Quantity, passenger / year],
-    days_per_year: typing.Annotated[Quantity, day / year],
 ) -> typing.Annotated[Quantity, passenger / day]:
     """Calculates the number of passengers per day globally.
 
@@ -22,7 +21,7 @@ def passengers_per_day(
         days_per_year: The number of days in a year.
 
     """
-    return passengers_per_year / days_per_year
+    return passengers_per_year.convert_to(passenger / day)
 
 
 @model.transform

--- a/src/aviation/fleet.py
+++ b/src/aviation/fleet.py
@@ -2,11 +2,19 @@
 
 __all__ = ("passengers_per_day", "required_global_fleet")
 
+import typing
+
 import camia_model as model
+from camia_model.units import Quantity, day, year
+
+from aviation.units import aircraft, journey, passenger
 
 
 @model.transform
-def passengers_per_day(passengers_per_year: float, days_per_year: float) -> float:
+def passengers_per_day(
+    passengers_per_year: typing.Annotated[Quantity, passenger / year],
+    days_per_year: typing.Annotated[Quantity, day / year],
+) -> typing.Annotated[Quantity, passenger / day]:
     """Calculates the number of passengers per day globally.
 
     Args:
@@ -19,8 +27,10 @@ def passengers_per_day(passengers_per_year: float, days_per_year: float) -> floa
 
 @model.transform
 def required_global_fleet(
-    passengers_per_day: float, seats_per_aircraft: float, flights_per_aircraft_per_day: float
-) -> float:
+    passengers_per_day: typing.Annotated[Quantity, passenger / day],
+    seats_per_aircraft: typing.Annotated[Quantity, passenger / aircraft],
+    flights_per_aircraft_per_day: typing.Annotated[Quantity, journey / (aircraft * day)],
+) -> typing.Annotated[Quantity, aircraft]:
     """Calculate the size of the required global fleet.
 
     Args:
@@ -29,4 +39,7 @@ def required_global_fleet(
         flights_per_aircraft_per_day: The average number of flight per aircraft per day.
 
     """
-    return passengers_per_day / (seats_per_aircraft * flights_per_aircraft_per_day)
+    aircraft_per_journey = 1.0 * aircraft / journey
+    return passengers_per_day / (
+        seats_per_aircraft * flights_per_aircraft_per_day * aircraft_per_journey
+    )

--- a/src/aviation/units.py
+++ b/src/aviation/units.py
@@ -1,0 +1,9 @@
+"""Additional units to support accurate annotations of transforms."""
+
+__all__ = ("passenger",)
+
+import camia_model as model
+
+passenger = model.units.Unit.new_named("passenger", relation=model.units.DIMENSIONLESS)
+aircraft = model.units.Unit.new_named("aircraft", relation=model.units.DIMENSIONLESS)
+journey = model.units.Unit.new_named("journey", relation=model.units.DIMENSIONLESS)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,8 +2,10 @@ import typing
 
 import camia_engine as engine
 import pytest
+from camia_model.units import day, year
 
 import aviation
+from aviation.units import aircraft, journey, passenger
 
 
 @pytest.fixture
@@ -14,22 +16,33 @@ def systems_model() -> engine.SystemsModel:
 @pytest.mark.parametrize(
     ("inputs", "output", "expected"),
     (
-        ({"passengers_per_year": 5_000_000_000.0}, "passengers_per_year", 5_000_000_000.0),
-        ({"required_global_fleet": 25_000.0}, "required_global_fleet", 25_000.0),
         (
-            {"passengers_per_year": 9_000_000_000.0, "days_per_year": 365.25},
-            "passengers_per_day",
-            24_640_657.0,
+            {"passengers_per_year": 5_000_000_000.0 * passenger / year},
+            "passengers_per_year",
+            5_000_000_000.0 * passenger / year,
+        ),
+        (
+            {"required_global_fleet": 25_000.0 * aircraft},
+            "required_global_fleet",
+            25_000.0 * aircraft,
         ),
         (
             {
-                "days_per_year": 365.25,
-                "passengers_per_year": 9_000_000_000.0,
-                "seats_per_aircraft": 181.0,
-                "flights_per_aircraft_per_day": 4.0,
+                "passengers_per_year": 9_000_000_000.0 * passenger / year,
+                "days_per_year": 365.25 * day / year,
+            },
+            "passengers_per_day",
+            24_640_657.0 * passenger / day,
+        ),
+        (
+            {
+                "days_per_year": 365.25 * day / year,
+                "passengers_per_year": 9_000_000_000.0 * passenger / year,
+                "seats_per_aircraft": 181.0 * passenger / aircraft,
+                "flights_per_aircraft_per_day": 4.0 * journey / (aircraft * day),
             },
             "required_global_fleet",
-            34_000.0,
+            34_000.0 * aircraft,
         ),
     ),
 )
@@ -40,4 +53,5 @@ def test_systems_model_evaluate(
     expected: float,
 ) -> None:
     result = systems_model.evaluate(inputs, output)
-    assert result == pytest.approx(expected, rel=0.1)
+    # assert result == pytest.approx(expected, rel=0.1)  # noqa: ERA001
+    assert 0.9 * expected < result < 1.1 * expected

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -30,14 +30,12 @@ def systems_model() -> engine.SystemsModel:
         (
             {
                 "passengers_per_year": 9_000_000_000.0 * passenger / year,
-                "days_per_year": 365.25 * day / year,
             },
             "passengers_per_day",
             24_640_657.0 * passenger / day,
         ),
         (
             {
-                "days_per_year": 365.25 * day / year,
                 "passengers_per_year": 9_000_000_000.0 * passenger / year,
                 "seats_per_aircraft": 181.0 * passenger / aircraft,
                 "flights_per_aircraft_per_day": 4.0 * journey / (aircraft * day),

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,6 +2,7 @@ import typing
 
 import camia_engine as engine
 import pytest
+import pytest_camia
 from camia_model.units import day, year
 
 import aviation
@@ -53,5 +54,4 @@ def test_systems_model_evaluate(
     expected: float,
 ) -> None:
     result = systems_model.evaluate(inputs, output)
-    # assert result == pytest.approx(expected, rel=0.1)  # noqa: ERA001
-    assert 0.9 * expected < result < 1.1 * expected
+    assert result == pytest_camia.approx(expected, rtol=0.1)

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -1,33 +1,44 @@
+import typing
+
 import pytest
+from camia_model.units import Quantity, day, year
 
 from aviation.fleet import passengers_per_day, required_global_fleet
+from aviation.units import aircraft, journey, passenger
 
 
 @pytest.mark.parametrize(
     ("passengers_per_year", "days_per_year", "expected_passengers_per_day"),
     (
-        (365_250_000.0, 365.25, 1_000_000.0),
-        (732_000_000.0, 366.0, 2_000_000.0),
+        (365_250_000.0 * passenger / year, 365.25 * day / year, 1_000_000.0 * passenger / day),
+        (732_000_000.0 * passenger / year, 366.0 * day / year, 2_000_000.0 * passenger / day),
     ),
 )
 def test_passengers_per_day(
-    passengers_per_year: float, days_per_year: float, expected_passengers_per_day: float
+    passengers_per_year: typing.Annotated[Quantity, passenger / year],
+    days_per_year: typing.Annotated[Quantity, day / year],
+    expected_passengers_per_day: typing.Annotated[Quantity, passenger / day],
 ) -> None:
     assert passengers_per_day(passengers_per_year, days_per_year) == expected_passengers_per_day
 
 
 def test_required_global_fleet() -> None:
-    days_per_year = 365.25
-    passengers_per_year = 9_000_000_000.0
-    seats_per_aircraft = 180.0
-    flights_per_aircraft_per_day = 4.0
+    days_per_year = 365.25 * day / year
+    passengers_per_year = 9_000_000_000.0 * passenger / year
+    seats_per_aircraft = 180.0 * passenger / aircraft
+    flights_per_aircraft_per_day = 4.0 * journey / (aircraft * day)
 
-    expected_required_global_fleet = 25_000.0
+    expected_required_global_fleet = 25_000.0 * aircraft
 
     result = required_global_fleet(
         passengers_per_day(passengers_per_year, days_per_year),
         seats_per_aircraft,
         flights_per_aircraft_per_day,
     )
-    tolerance = 10_000.0
-    assert result == pytest.approx(expected_required_global_fleet, abs=tolerance)
+    tolerance = 10_000.0 * aircraft
+    # assert result == pytest.approx(expected_required_global_fleet, abs=tolerance)  # noqa: ERA001
+    assert (
+        expected_required_global_fleet - tolerance
+        < result
+        < expected_required_global_fleet + tolerance
+    )

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -9,22 +9,20 @@ from aviation.units import aircraft, journey, passenger
 
 
 @pytest.mark.parametrize(
-    ("passengers_per_year", "days_per_year", "expected_passengers_per_day"),
+    ("passengers_per_year", "expected_passengers_per_day"),
     (
-        (365_250_000.0 * passenger / year, 365.25 * day / year, 1_000_000.0 * passenger / day),
-        (732_000_000.0 * passenger / year, 366.0 * day / year, 2_000_000.0 * passenger / day),
+        (365_250_000.0 * passenger / year, 1_000_000.0 * passenger / day),
+        (730_500_000.0 * passenger / year, 2_000_000.0 * passenger / day),
     ),
 )
 def test_passengers_per_day(
     passengers_per_year: typing.Annotated[Quantity, passenger / year],
-    days_per_year: typing.Annotated[Quantity, day / year],
     expected_passengers_per_day: typing.Annotated[Quantity, passenger / day],
 ) -> None:
-    assert passengers_per_day(passengers_per_year, days_per_year) == expected_passengers_per_day
+    assert passengers_per_day(passengers_per_year) == expected_passengers_per_day
 
 
 def test_required_global_fleet() -> None:
-    days_per_year = 365.25 * day / year
     passengers_per_year = 9_000_000_000.0 * passenger / year
     seats_per_aircraft = 180.0 * passenger / aircraft
     flights_per_aircraft_per_day = 4.0 * journey / (aircraft * day)
@@ -32,7 +30,7 @@ def test_required_global_fleet() -> None:
     expected_required_global_fleet = 25_000.0 * aircraft
 
     result = required_global_fleet(
-        passengers_per_day(passengers_per_year, days_per_year),
+        passengers_per_day(passengers_per_year),
         seats_per_aircraft,
         flights_per_aircraft_per_day,
     )

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -1,6 +1,7 @@
 import typing
 
 import pytest
+import pytest_camia
 from camia_model.units import Quantity, day, year
 
 from aviation.fleet import passengers_per_day, required_global_fleet
@@ -35,10 +36,5 @@ def test_required_global_fleet() -> None:
         seats_per_aircraft,
         flights_per_aircraft_per_day,
     )
-    tolerance = 10_000.0 * aircraft
-    # assert result == pytest.approx(expected_required_global_fleet, abs=tolerance)  # noqa: ERA001
-    assert (
-        expected_required_global_fleet - tolerance
-        < result
-        < expected_required_global_fleet + tolerance
-    )
+    tolerance = 10_000.0
+    assert result == pytest_camia.approx(expected_required_global_fleet, atol=tolerance)

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,7 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-camia" },
     { name = "ruff" },
 ]
 docs = [
@@ -36,6 +37,7 @@ dev = [
     { name = "mypy", specifier = ">=1.17.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.4.1" },
+    { name = "pytest-camia", specifier = ">=0.3.3" },
     { name = "ruff", specifier = ">=0.12.3" },
 ]
 docs = [
@@ -703,6 +705,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+]
+
+[[package]]
+name = "pytest-camia"
+version = "0.3.3"
+source = { registry = "https://gitlab.developers.cam.ac.uk/api/v4/projects/8115/packages/pypi/simple" }
+dependencies = [
+    { name = "camia-model" },
+    { name = "pytest" },
+]
+sdist = { url = "https://gitlab.developers.cam.ac.uk/api/v4/projects/8115/packages/pypi/files/8d9884482008d0aa1ebfc7de58de2d4c6ecb8403530eafcabded589cfa09c329/pytest_camia-0.3.3.tar.gz", hash = "sha256:8d9884482008d0aa1ebfc7de58de2d4c6ecb8403530eafcabded589cfa09c329" }
+wheels = [
+    { url = "https://gitlab.developers.cam.ac.uk/api/v4/projects/8115/packages/pypi/files/09a40b27a9271ad30bc02df5858402f09e2cdf4e68412d66456c7c9449fb5cc3/pytest_camia-0.3.3-py3-none-any.whl", hash = "sha256:09a40b27a9271ad30bc02df5858402f09e2cdf4e68412d66456c7c9449fb5cc3" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR refactors the repository to use camia-moel's unit system. It adds custom units for `journey`, `aircraft` and `passenger` to show how these can be added and used with units already implemented in camia-model. It also shows how camia-model's unit conversion (using `Quantity.convert_to(...)`) can be used to convert one unit to another whilst mainting dimensionality.

Finally, it adds the AIA's pytest-camia to the `dev` dependency group so that it can be used in tests to compare approximate equality for `Quantity` instances and to run automated units checking tests on all transforms in the `src/` directory.